### PR TITLE
Feature/direct table input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ build/
 
 # Misc
 .DS_Store
+.codex
 
 # 
 playgrounds/dev

--- a/packages/svelte-timeseries/README.md
+++ b/packages/svelte-timeseries/README.md
@@ -110,11 +110,11 @@ Requirements:
 <script lang="ts">
 	import { SvelteTimeSeries } from '@qtsurfer/svelte-timeseries';
 
-const tables = {
-	temps: {
-		url: '/temps_gzip.parquet',
-		mainColumn: 'temp'
-	}
+	const tables = {
+		temps: {
+			url: '/temps_gzip.parquet',
+			mainColumn: 'temp'
+		}
 	};
 
 	const markers = {
@@ -124,12 +124,7 @@ const tables = {
 	};
 </script>
 
-<SvelteTimeSeries
-	table={tables}
-	{markers}
-	debug={false}
-	externalManagerLegend={true}
-/>
+<SvelteTimeSeries table={tables} {markers} debug={false} externalManagerLegend={true} />
 ```
 
 You can also pass a Parquet file directly instead of a URL:
@@ -150,7 +145,11 @@ You can also pass a Parquet file directly instead of a URL:
 		: {};
 </script>
 
-<input type="file" accept=".parquet" onchange={(event) => (parquetFile = event.currentTarget.files?.[0] ?? null)} />
+<input
+	type="file"
+	accept=".parquet"
+	onchange={(event) => (parquetFile = event.currentTarget.files?.[0] ?? null)}
+/>
 
 {#if parquetFile}
 	<SvelteTimeSeries table={tables} />
@@ -159,14 +158,14 @@ You can also pass a Parquet file directly instead of a URL:
 
 ## Component API
 
-| Prop                  | Type                                                                            | Description                                                                                        |
-| --------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `table`               | `Record<string, { mainColumn: string; columnsSelect?: string[] } & ({ url: string } \| { parquet: Blob \| File \| ArrayBuffer \| Uint8Array })>` | Defines the Parquet sources and their primary column; the object key becomes the DuckDB view name. |
-| `markers?`            | `MarkersTableOptions`                                                           | Table and JSON column used to build the `markers` view (`shape`, `color`, `position`, `text`).     |
-| `debug?`              | `boolean` (default `true`)                                                      | Enables verbose DuckDB/builder logging.                                                            |
-| `externalManagerLegend?` | `boolean` (default `true`)                                                   | Passes `externalManagerLegend` to `TimeSeriesChartBuilder`. Disable it to let the chart manage the legend internally. |
-| `columnsSnippet?`     | `Snippet<[ColumnsProps]>`                                                       | Overrides the column toggle panel.                                                                 |
-| `performanceSnippet?` | `Snippet<[PerformanceProps]>`                                                   | Overrides the performance/metrics panel.                                                           |
+| Prop                     | Type                                                                                                                                             | Description                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `table`                  | `Record<string, { mainColumn: string; columnsSelect?: string[] } & ({ url: string } \| { parquet: Blob \| File \| ArrayBuffer \| Uint8Array })>` | Defines the Parquet sources and their primary column; the object key becomes the DuckDB view name.                    |
+| `markers?`               | `MarkersTableOptions`                                                                                                                            | Table and JSON column used to build the `markers` view (`shape`, `color`, `position`, `text`).                        |
+| `debug?`                 | `boolean` (default `true`)                                                                                                                       | Enables verbose DuckDB/builder logging.                                                                               |
+| `externalManagerLegend?` | `boolean` (default `true`)                                                                                                                       | Passes `externalManagerLegend` to `TimeSeriesChartBuilder`. Disable it to let the chart manage the legend internally. |
+| `columnsSnippet?`        | `Snippet<[ColumnsProps]>`                                                                                                                        | Overrides the column toggle panel.                                                                                    |
+| `performanceSnippet?`    | `Snippet<[PerformanceProps]>`                                                                                                                    | Overrides the performance/metrics panel.                                                                              |
 
 ## TimeSeriesFacade in practice
 

--- a/packages/svelte-timeseries/README.md
+++ b/packages/svelte-timeseries/README.md
@@ -102,7 +102,7 @@ Forces Vite to include this library in the SSR build pipeline.
 Requirements:
 
 - SvelteKit project with TypeScript enabled.
-- Ability to serve Parquet/Arrow files (local assets or CDN).
+- Ability to provide Parquet files either by URL or directly in memory.
 
 ## Getting started
 
@@ -110,11 +110,11 @@ Requirements:
 <script lang="ts">
 	import { SvelteTimeSeries } from '@qtsurfer/svelte-timeseries';
 
-	const tables = {
-		temps: {
-			url: '/temps_gzip.parquet',
-			mainColumn: 'temp'
-		}
+const tables = {
+	temps: {
+		url: '/temps_gzip.parquet',
+		mainColumn: 'temp'
+	}
 	};
 
 	const markers = {
@@ -124,16 +124,47 @@ Requirements:
 	};
 </script>
 
-<SvelteTimeSeries table={tables} {markers} debug={false} />
+<SvelteTimeSeries
+	table={tables}
+	{markers}
+	debug={false}
+	externalManagerLegend={true}
+/>
+```
+
+You can also pass a Parquet file directly instead of a URL:
+
+```svelte
+<script lang="ts">
+	import { SvelteTimeSeries } from '@qtsurfer/svelte-timeseries';
+
+	let parquetFile: File | null = null;
+
+	$: tables = parquetFile
+		? {
+				temps: {
+					parquet: parquetFile,
+					mainColumn: 'temp'
+				}
+			}
+		: {};
+</script>
+
+<input type="file" accept=".parquet" onchange={(event) => (parquetFile = event.currentTarget.files?.[0] ?? null)} />
+
+{#if parquetFile}
+	<SvelteTimeSeries table={tables} />
+{/if}
 ```
 
 ## Component API
 
 | Prop                  | Type                                                                            | Description                                                                                        |
 | --------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `table`               | `Record<string, { url: string; mainColumn: string; columnsSelect?: string[] }>` | Defines the Parquet sources and their primary column; the object key becomes the DuckDB view name. |
+| `table`               | `Record<string, { mainColumn: string; columnsSelect?: string[] } & ({ url: string } \| { parquet: Blob \| File \| ArrayBuffer \| Uint8Array })>` | Defines the Parquet sources and their primary column; the object key becomes the DuckDB view name. |
 | `markers?`            | `MarkersTableOptions`                                                           | Table and JSON column used to build the `markers` view (`shape`, `color`, `position`, `text`).     |
 | `debug?`              | `boolean` (default `true`)                                                      | Enables verbose DuckDB/builder logging.                                                            |
+| `externalManagerLegend?` | `boolean` (default `true`)                                                   | Passes `externalManagerLegend` to `TimeSeriesChartBuilder`. Disable it to let the chart manage the legend internally. |
 | `columnsSnippet?`     | `Snippet<[ColumnsProps]>`                                                       | Overrides the column toggle panel.                                                                 |
 | `performanceSnippet?` | `Snippet<[PerformanceProps]>`                                                   | Overrides the performance/metrics panel.                                                           |
 

--- a/packages/svelte-timeseries/src/lib/TimeSeriesFacade.ts
+++ b/packages/svelte-timeseries/src/lib/TimeSeriesFacade.ts
@@ -41,6 +41,20 @@ export default class TimeSeriesFacade {
 		this.timeSeriesChartBuilder.addDimension(result, columnesSelect);
 	}
 
+	async loadAllColumns(table: string, excludeColumns: string[] = []): Promise<Columns> {
+		const excluded = new Set(excludeColumns);
+		const columns = this.duckDb.getColumns(table);
+
+		for (const column of columns) {
+			if (excluded.has(column) || this.isLoadedColumns(column)) {
+				continue;
+			}
+			await this.addDimension(table, column);
+		}
+
+		return this.getColumns(table);
+	}
+
 	getColumns(table: string): Columns {
 		const columns = this.duckDb.getColumns(table);
 		const selected = this.timeSeriesChartBuilder.getLegendStatus();

--- a/packages/svelte-timeseries/src/lib/component/SvelteTimeSeries.svelte
+++ b/packages/svelte-timeseries/src/lib/component/SvelteTimeSeries.svelte
@@ -29,6 +29,7 @@
 		table,
 		markers,
 		debug = true,
+		externalManagerLegend = true,
 		columnsSnippet,
 		markersSnippet,
 		performanceSnippet,
@@ -41,6 +42,7 @@
 		table: Tables;
 		markers?: MarkersTableOptions;
 		debug: boolean;
+		externalManagerLegend?: boolean;
 		columnsSnippet?: Snippet<[DataColumnsProps]>;
 		markersSnippet?: Snippet<[MarkersProps]>;
 		performanceSnippet?: Snippet<[PerformanceProps]>;
@@ -65,19 +67,21 @@
 		loading = true;
 		const duckDb = await DuckDB.create(table, markers, debug);
 		const timeSeriesBuilder = new TimeSeriesChartBuilder(EChartInstance, {
-			externalManagerLegend: true
+			externalManagerLegend
 		});
 		timeSeriesFacade = new TimeSeriesFacade(duckDb, timeSeriesBuilder);
 
 		const columnsSelect = table[tableName].mainColumn;
 		await timeSeriesFacade.initialize(tableName, columnsSelect);
-
-		loading = false;
+		if (!externalManagerLegend) {
+			await timeSeriesFacade.loadAllColumns(tableName, [columnsSelect]);
+		}
 
 		if (markers) {
 			markersData = await timeSeriesFacade.loadMarkers(markers.targetDimension);
 		}
 
+		loading = false;
 		timer.end = performance.now();
 		columns = timeSeriesFacade.getColumns(tableName);
 		onFacadeReady?.(timeSeriesFacade);

--- a/packages/svelte-timeseries/src/lib/duckdb/DuckDB.ts
+++ b/packages/svelte-timeseries/src/lib/duckdb/DuckDB.ts
@@ -1,8 +1,4 @@
-import {
-	AsyncDuckDB,
-	AsyncDuckDBConnection,
-	DuckDBDataProtocol
-} from '@duckdb/duckdb-wasm';
+import { AsyncDuckDB, AsyncDuckDBConnection, DuckDBDataProtocol } from '@duckdb/duckdb-wasm';
 import { createAsyncDuckDB } from './duckdb-wasm';
 import { Schema, Table } from 'apache-arrow';
 
@@ -278,10 +274,7 @@ export class DuckDB<T extends Tables> {
 	 * @param url The url of the table
 	 * @private
 	 */
-	private async buildTablesAndSchemas(
-		name: keyof T,
-		tableConfiguration: TableData
-	) {
+	private async buildTablesAndSchemas(name: keyof T, tableConfiguration: TableData) {
 		return await this.execute(async (conn) => {
 			if (this.debug) console.log('Registering tables and schemas...');
 
@@ -356,7 +349,10 @@ export class DuckDB<T extends Tables> {
 		}, 'buildTablesAndSchemas - ' + name.toString());
 	}
 
-	private async registerParquetSource(viewName: string, tableConfiguration: TableData): Promise<string> {
+	private async registerParquetSource(
+		viewName: string,
+		tableConfiguration: TableData
+	): Promise<string> {
 		if (tableConfiguration.url !== undefined) {
 			return tableConfiguration.url;
 		}
@@ -473,7 +469,9 @@ export class DuckDB<T extends Tables> {
 		const casts: Record<string, TargetType> = {};
 
 		fields.forEach((f, idx) => {
-			if (TIMESTAMP_COLUMN_CANDIDATES.includes(f.name as (typeof TIMESTAMP_COLUMN_CANDIDATES)[number])) {
+			if (
+				TIMESTAMP_COLUMN_CANDIDATES.includes(f.name as (typeof TIMESTAMP_COLUMN_CANDIDATES)[number])
+			) {
 				casts[f.name] = this.isTimestampLikeType(f.type) ? 'TIMESTAMP' : 'TIMESTAMP(ms)';
 				return;
 			}

--- a/packages/svelte-timeseries/src/lib/duckdb/DuckDB.ts
+++ b/packages/svelte-timeseries/src/lib/duckdb/DuckDB.ts
@@ -1,4 +1,8 @@
-import { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm';
+import {
+	AsyncDuckDB,
+	AsyncDuckDBConnection,
+	DuckDBDataProtocol
+} from '@duckdb/duckdb-wasm';
 import { createAsyncDuckDB } from './duckdb-wasm';
 import { Schema, Table } from 'apache-arrow';
 
@@ -10,7 +14,24 @@ export type MarkersTableOptions = {
 	targetDimension: string;
 };
 
-type TableData = { url: string; mainColumn: string; columnsSelect?: string[] };
+export type ParquetSource = Blob | ArrayBuffer | Uint8Array;
+
+type TableDataBase = {
+	mainColumn: string;
+	columnsSelect?: string[];
+};
+
+type TableDataFromUrl = TableDataBase & {
+	url: string;
+	parquet?: never;
+};
+
+type TableDataFromParquet = TableDataBase & {
+	url?: never;
+	parquet: ParquetSource;
+};
+
+export type TableData = TableDataFromUrl | TableDataFromParquet;
 export type Tables = Record<string, TableData>;
 
 type IconType =
@@ -53,6 +74,7 @@ type DuckDBType =
 
 // Allows you to specify TIMESTAMP with unit: 'TIMESTAMP(ms)' etc.
 type TargetType = DuckDBType | `TIMESTAMP(${EpochUnit})`;
+const TIMESTAMP_COLUMN_CANDIDATES = ['_ts', 'ts', '_t', 't'] as const;
 
 export class DuckDB<T extends Tables> {
 	private _conn?: AsyncDuckDBConnection;
@@ -87,7 +109,7 @@ export class DuckDB<T extends Tables> {
 	}
 
 	get tsColumnQuery() {
-		return `epoch_ms("${this._tsColumn}")::DOUBLE as ${this._tsColumn}`;
+		return this.escapeIdent(this._tsColumn);
 	}
 
 	/**
@@ -165,7 +187,7 @@ export class DuckDB<T extends Tables> {
 
 				if (!omitTimestamp) {
 					const tsRaw = tsVector.get(i);
-					tsValues.push(tsRaw);
+					tsValues.push(this.normalizeTimestampValue(tsRaw));
 				}
 			}
 		}
@@ -244,8 +266,7 @@ export class DuckDB<T extends Tables> {
 	 */
 	private async registerData() {
 		for (const [name, data] of Object.entries(this._tables) as [keyof T, TableData][]) {
-			const { url, ...confg } = data;
-			await this.buildTablesAndSchemas(name, data.url, confg);
+			await this.buildTablesAndSchemas(name, data);
 			continue;
 		}
 	}
@@ -259,14 +280,14 @@ export class DuckDB<T extends Tables> {
 	 */
 	private async buildTablesAndSchemas(
 		name: keyof T,
-		url: string,
-		tableConfiguration?: Pick<TableData, 'mainColumn' | 'columnsSelect'>
+		tableConfiguration: TableData
 	) {
 		return await this.execute(async (conn) => {
 			if (this.debug) console.log('Registering tables and schemas...');
 
 			const viewName = String(name);
 			const tempViewName = `__temp_${viewName}`;
+			const sourcePath = await this.registerParquetSource(viewName, tableConfiguration);
 
 			const columnsSelect = tableConfiguration?.columnsSelect?.map((c) => this.escapeIdent(c)) ?? [
 				'*'
@@ -280,7 +301,7 @@ export class DuckDB<T extends Tables> {
 
 			// Create temp view from parquet file
 			await conn.query(
-				`CREATE OR REPLACE VIEW ${this.escapeIdent(tempViewName)} AS SELECT ${selectColumns} FROM parquet_scan('${url}')`
+				`CREATE OR REPLACE VIEW ${this.escapeIdent(tempViewName)} AS SELECT ${selectColumns} FROM parquet_scan('${sourcePath}')`
 			);
 
 			// detected the initial schema of the temp view
@@ -289,6 +310,13 @@ export class DuckDB<T extends Tables> {
 			);
 
 			const initialSchema: ColumsSchema = initialSchemaData.toArray();
+			const sourceTimestampField = this.getTimestampSourceField(initialSchema);
+
+			if (!sourceTimestampField) {
+				throw new Error(
+					`Time column not found in "${viewName}". Expected one of: ${TIMESTAMP_COLUMN_CANDIDATES.join(', ')}`
+				);
+			}
 
 			// use the initial schema to build the casted select
 			const targetCasts = this.autoDetectFields(initialSchema);
@@ -302,7 +330,7 @@ export class DuckDB<T extends Tables> {
 			// Create markers view if needed
 			if (this._markersColumn?.table === viewName) {
 				const columnesSelect = [
-					`${this.sqlTimestampFromEpoch(this._tsColumn, 'ms')} AS ${this._tsColumn}`,
+					`${this.buildTimestampSelect(sourceTimestampField)} AS ${this._tsColumn}`,
 					`regexp_replace(CAST(json_extract(${this._markersColumn.targetColumn}, '$.shape') AS VARCHAR), '^"(.*)"$', '\\1') AS shape`,
 					`regexp_replace(CAST(json_extract(${this._markersColumn.targetColumn}, '$.color') AS VARCHAR), '^"(.*)"$', '\\1') AS color`,
 					`regexp_replace(CAST(json_extract(${this._markersColumn.targetColumn}, '$.position') AS VARCHAR), '^"(.*)"$', '\\1') AS position`,
@@ -326,6 +354,43 @@ export class DuckDB<T extends Tables> {
 			// Store the final schema
 			return finalSchema;
 		}, 'buildTablesAndSchemas - ' + name.toString());
+	}
+
+	private async registerParquetSource(viewName: string, tableConfiguration: TableData): Promise<string> {
+		if (tableConfiguration.url !== undefined) {
+			return tableConfiguration.url;
+		}
+
+		const registeredFileName = `${viewName}.parquet`;
+		const parquet = tableConfiguration.parquet;
+
+		if (parquet instanceof Uint8Array) {
+			await this.db.registerFileBuffer(registeredFileName, parquet);
+			return registeredFileName;
+		}
+
+		if (parquet instanceof ArrayBuffer) {
+			await this.db.registerFileBuffer(registeredFileName, new Uint8Array(parquet));
+			return registeredFileName;
+		}
+
+		if (parquet instanceof Blob) {
+			if (typeof File !== 'undefined' && parquet instanceof File) {
+				await this.db.registerFileHandle(
+					registeredFileName,
+					parquet,
+					DuckDBDataProtocol.BROWSER_FILEREADER,
+					true
+				);
+				return registeredFileName;
+			}
+
+			const buffer = new Uint8Array(await parquet.arrayBuffer());
+			await this.db.registerFileBuffer(registeredFileName, buffer);
+			return registeredFileName;
+		}
+
+		throw new Error('Unsupported parquet source. Use url, Blob/File, ArrayBuffer, or Uint8Array.');
 	}
 
 	/**
@@ -359,7 +424,10 @@ export class DuckDB<T extends Tables> {
 		const sql = `SELECT * FROM markers`;
 
 		const result = await this.query(sql);
-		return result.toArray();
+		return result.toArray().map((row) => ({
+			...row,
+			_ts: this.normalizeTimestampValue(row._ts)
+		}));
 	}
 
 	/**
@@ -405,8 +473,8 @@ export class DuckDB<T extends Tables> {
 		const casts: Record<string, TargetType> = {};
 
 		fields.forEach((f, idx) => {
-			if (['_ts', 'ts'].includes(f.name)) {
-				casts[f.name] = 'TIMESTAMP(ms)';
+			if (TIMESTAMP_COLUMN_CANDIDATES.includes(f.name as (typeof TIMESTAMP_COLUMN_CANDIDATES)[number])) {
+				casts[f.name] = this.isTimestampLikeType(f.type) ? 'TIMESTAMP' : 'TIMESTAMP(ms)';
 				return;
 			}
 
@@ -430,6 +498,38 @@ export class DuckDB<T extends Tables> {
 		return casts;
 	}
 
+	private getTimestampSourceField(fields: ColumsSchema): ColumsSchema[number] | undefined {
+		return fields.find((field) =>
+			TIMESTAMP_COLUMN_CANDIDATES.includes(
+				field.name as (typeof TIMESTAMP_COLUMN_CANDIDATES)[number]
+			)
+		);
+	}
+
+	private isTimestampLikeType(type: string): boolean {
+		return type.toUpperCase().includes('TIMESTAMP') || type.toUpperCase() === 'DATE';
+	}
+
+	private buildTimestampSelect(field: ColumsSchema[number]): string {
+		const column = this.escapeIdent(field.name);
+		if (this.isTimestampLikeType(field.type)) {
+			return field.type.toUpperCase() === 'DATE' ? `CAST(${column} AS TIMESTAMP)` : column;
+		}
+		return this.sqlTimestampFromEpoch(column, 'ms');
+	}
+
+	private normalizeTimestampValue(value: unknown): number {
+		if (value instanceof Date) {
+			return value.getTime();
+		}
+
+		if (typeof value === 'bigint') {
+			return Number(value);
+		}
+
+		return Number(value);
+	}
+
 	/**
 	 * Build the casted type
 	 */
@@ -439,6 +539,9 @@ export class DuckDB<T extends Tables> {
 
 		for (const [col, target] of Object.entries(casts)) {
 			const colSQL = this.escapeIdent(col);
+			const isTimestampColumn = TIMESTAMP_COLUMN_CANDIDATES.includes(
+				col as (typeof TIMESTAMP_COLUMN_CANDIDATES)[number]
+			);
 
 			// Timestamp with unit
 			const m = typeof target === 'string' ? target.match(/^TIMESTAMP\((s|ms|us|ns)\)$/i) : null;
@@ -451,7 +554,7 @@ export class DuckDB<T extends Tables> {
 
 			// TIMESTAMP Without unit
 			if (target === 'TIMESTAMP') {
-				parts.push(`${colSQL} AS ${colSQL}`);
+				parts.push(`${colSQL} AS ${isTimestampColumn ? this._tsColumn : colSQL}`);
 				continue;
 			}
 

--- a/packages/svelte-timeseries/src/routes/+page.svelte
+++ b/packages/svelte-timeseries/src/routes/+page.svelte
@@ -1,38 +1,37 @@
 <script lang="ts">
 	import '../css/main.css';
 	import { SvelteTimeSeries } from '$lib';
-	import { type MarkersTableOptions, type Tables } from '$lib/duckdb/DuckDB';
-	import { Schema } from 'apache-arrow';
+	import { DuckDB, type MarkersTableOptions, type Tables } from '$lib/duckdb/DuckDB';
 	import { onMount } from 'svelte';
 	import EyeIcon from '$lib/icon/EyeIcon.svelte';
 	import EyeOffIcon from '$lib/icon/EyeOffIcon.svelte';
 	import Icon from '@iconify/svelte';
 
-	let selected = $state<number | null>(2);
-	let baseUrl = $state<string>(typeof window !== 'undefined' ? window.location.href : '');
-
-	type ConfigurationType = {
-		duckDb?: {
-			schema: Schema;
-			columns: string[];
-			markers: any[];
-		};
-		builder?: {
-			dimensions: {
-				x: string;
-				y: string[];
-			};
-			legendStatus: Record<string, boolean>;
-		};
+	type DemoConfiguration = {
+		name: string;
+		markers?: MarkersTableOptions;
+		tables: Tables;
 	};
 
-	let configurations = $derived<
-		{
-			name: string;
-			markers?: MarkersTableOptions;
-			tables: Tables;
-		}[]
-	>([
+	type SourceMode = 'url' | 'file';
+	type LegendMode = 'external' | 'internal';
+
+	const CUSTOM_CONFIGURATION_ID = 'custom';
+
+	let selected = $state('preset:2');
+	let baseUrl = $state<string>(typeof window !== 'undefined' ? window.location.href : '');
+	let sourceMode = $state<SourceMode>('file');
+	let legendMode = $state<LegendMode>('external');
+	let customUrl = $state('');
+	let customFile = $state<File | null>(null);
+	let customColumns = $state<string[]>([]);
+	let customMainColumn = $state('');
+	let customError = $state('');
+	let inspectingCustomFile = $state(false);
+	let loadedCustomConfiguration = $state<DemoConfiguration | null>(null);
+	let customRenderNonce = $state(0);
+
+	let configurations = $derived<DemoConfiguration[]>([
 		{
 			name: 'Minimal data',
 			tables: {
@@ -82,12 +81,155 @@
 		}
 	]);
 
-	onMount(async () => {
+	const activeConfiguration = $derived<DemoConfiguration | null>(
+		selected === CUSTOM_CONFIGURATION_ID
+			? loadedCustomConfiguration
+			: configurations[Number(selected.replace('preset:', ''))] ?? null
+	);
+
+	const renderKey = $derived(
+		selected === CUSTOM_CONFIGURATION_ID
+			? `${CUSTOM_CONFIGURATION_ID}-${customRenderNonce}-${legendMode}`
+			: `${selected}-${legendMode}`
+	);
+	const showCustomSidebar = $derived(legendMode === 'external');
+
+	function setSourceMode(mode: SourceMode) {
+		sourceMode = mode;
+		customError = '';
+		loadedCustomConfiguration = null;
+
+		if (mode === 'url') {
+			customFile = null;
+			customColumns = [];
+			customMainColumn = customMainColumn || 'temp';
+		} else {
+			customUrl = '';
+			customColumns = [];
+			customMainColumn = '';
+		}
+	}
+
+	async function inspectCustomFile(file: File) {
+		inspectingCustomFile = true;
+		customError = '';
+		customColumns = [];
+		customMainColumn = '';
+		loadedCustomConfiguration = null;
+
+		let duckDb:
+			| Awaited<
+					ReturnType<
+						typeof DuckDB.create<{
+							uploaded_preview: {
+								parquet: File;
+								mainColumn: string;
+							};
+						}>
+					>
+			  >
+			| undefined;
+
+		try {
+			duckDb = await DuckDB.create(
+				{
+					uploaded_preview: {
+						parquet: file,
+						mainColumn: '__preview__'
+					}
+				},
+				undefined,
+				false
+			);
+
+			customColumns = duckDb.getColumns('uploaded_preview');
+			customMainColumn = customColumns[0] ?? '';
+
+			if (!customColumns.length) {
+				customError = 'No plottable columns were found in the parquet file.';
+			}
+		} catch (error) {
+			customError =
+				error instanceof Error ? error.message : 'The parquet file could not be inspected.';
+		} finally {
+			await duckDb?.closeConnection();
+			inspectingCustomFile = false;
+		}
+	}
+
+	async function onCustomFileChange(event: Event) {
+		const input = event.currentTarget as HTMLInputElement | null;
+		const file = input?.files?.[0] ?? null;
+		customFile = file;
+		customError = '';
+		loadedCustomConfiguration = null;
+
+		if (file) {
+			await inspectCustomFile(file);
+		}
+	}
+
+	function clearCustomFile() {
+		customFile = null;
+		customColumns = [];
+		customMainColumn = '';
+		customError = '';
+		loadedCustomConfiguration = null;
+	}
+
+	function loadCustomSource() {
+		customError = '';
+
+		if (sourceMode === 'url') {
+			const url = customUrl.trim();
+			const mainColumn = customMainColumn.trim();
+
+			if (!url || !mainColumn) {
+				customError = 'Complete the URL and the main column before loading.';
+				return;
+			}
+
+			loadedCustomConfiguration = {
+				name: `Remote parquet: ${url}`,
+				tables: {
+					remote: {
+						url,
+						mainColumn
+					}
+				}
+			};
+		} else {
+			if (!customFile) {
+				customError = 'Select a parquet file first.';
+				return;
+			}
+
+			if (!customMainColumn) {
+				customError = 'Select the main column before loading.';
+				return;
+			}
+
+			loadedCustomConfiguration = {
+				name: `Local parquet: ${customFile.name}`,
+				tables: {
+					uploaded: {
+						parquet: customFile,
+						mainColumn: customMainColumn
+					}
+				}
+			};
+		}
+
+		customRenderNonce += 1;
+		selected = CUSTOM_CONFIGURATION_ID;
+	}
+
+	onMount(() => {
 		baseUrl = window.location.href;
 	});
 </script>
 
-<div class="grid grid-rows-[auto_1fr] h-screen relative">
+<div class="grid grid-rows-[auto_auto_1fr] h-screen relative">
 	<div class="navbar shadow-sm bg-primary">
 		<div class="navbar-start text-primary-content">
 			<div class="flex gap-2 items-baseline text-2xl font-bold">
@@ -95,15 +237,7 @@
 			</div>
 		</div>
 
-		<div class="navbar-center">
-			<select class="select w-full max-w-md" bind:value={selected}>
-				{#each configurations as config, i}
-					<option value={i}>
-						{config.name}
-					</option>
-				{/each}
-			</select>
-		</div>
+		<div class="navbar-center"></div>
 		<div class="navbar-end">
 			<div class="flex gap-8 text-primary-content px-4">
 				<a href="https://github.com/QTSurfer/svelte-timeseries" target="_blank">
@@ -130,20 +264,154 @@
 		</div>
 	</div>
 
+	<div class="border-b bg-base-200 px-4 py-3">
+		<div class="flex flex-wrap items-end gap-3">
+			<label class="form-control w-full max-w-sm">
+				<div class="label pb-1">
+					<span class="label-text font-semibold">Scenario</span>
+				</div>
+				<select class="select select-bordered" bind:value={selected}>
+					{#each configurations as config, i}
+						<option value={`preset:${i}`}>
+							{config.name}
+						</option>
+					{/each}
+					<option value={CUSTOM_CONFIGURATION_ID}>Custom source</option>
+				</select>
+			</label>
+
+			<label class="form-control w-full max-w-48">
+				<div class="label pb-1">
+					<span class="label-text font-semibold">Legend</span>
+				</div>
+				<select class="select select-bordered" bind:value={legendMode}>
+					<option value="external">External</option>
+					<option value="internal">Internal</option>
+				</select>
+			</label>
+
+			{#if selected === CUSTOM_CONFIGURATION_ID}
+				<div class="join">
+					<button
+						class={`btn join-item ${sourceMode === 'url' ? 'btn-primary' : 'btn-outline'}`}
+						onclick={() => setSourceMode('url')}
+					>
+						URL
+					</button>
+					<button
+						class={`btn join-item ${sourceMode === 'file' ? 'btn-primary' : 'btn-outline'}`}
+						onclick={() => setSourceMode('file')}
+					>
+						File
+					</button>
+				</div>
+
+				{#if sourceMode === 'url'}
+					<label class="form-control w-full max-w-md">
+						<div class="label pb-1">
+							<span class="label-text font-semibold">Parquet URL</span>
+						</div>
+						<input
+							class="input input-bordered"
+							type="url"
+							bind:value={customUrl}
+							placeholder="https://example.com/data.parquet"
+						/>
+					</label>
+
+					<label class="form-control w-full max-w-xs">
+						<div class="label pb-1">
+							<span class="label-text font-semibold">Main column</span>
+						</div>
+						<input
+							class="input input-bordered"
+							type="text"
+							bind:value={customMainColumn}
+							placeholder="price"
+						/>
+					</label>
+				{:else}
+					<label class="form-control w-full max-w-sm">
+						<div class="label pb-1">
+							<span class="label-text font-semibold">Parquet file</span>
+						</div>
+						<input
+							class="file-input file-input-bordered"
+							type="file"
+							accept=".parquet,.pqt,application/octet-stream"
+							onchange={onCustomFileChange}
+						/>
+					</label>
+
+					{#if customFile}
+						<label class="form-control w-full max-w-xs">
+							<div class="label pb-1">
+								<span class="label-text font-semibold">Main column</span>
+							</div>
+							<select
+								class="select select-bordered"
+								bind:value={customMainColumn}
+								disabled={inspectingCustomFile || customColumns.length === 0}
+							>
+								<option value="" disabled selected={!customMainColumn}>
+									Select column
+								</option>
+								{#each customColumns as column}
+									<option value={column}>{column}</option>
+								{/each}
+							</select>
+						</label>
+
+						<button class="btn btn-ghost" onclick={clearCustomFile}>Clear</button>
+					{/if}
+				{/if}
+
+				<button
+					class="btn btn-primary"
+					onclick={loadCustomSource}
+					disabled={
+						sourceMode === 'url'
+							? !customUrl.trim() || !customMainColumn.trim()
+							: !customFile || !customMainColumn || inspectingCustomFile
+					}
+				>
+					{inspectingCustomFile ? 'Reading parquet...' : 'Load'}
+				</button>
+			{/if}
+		</div>
+
+		{#if selected === CUSTOM_CONFIGURATION_ID}
+			<div class="mt-3 text-sm text-base-content/70">
+				The parquet file can provide the time column as <code>_ts</code>, <code>ts</code>,
+				<code>_t</code>, or <code>t</code>. In file mode: 1. select the parquet file, 2. choose
+				the <code>mainColumn</code>, 3. press <code>Load</code>.
+			</div>
+		{/if}
+
+		{#if selected === CUSTOM_CONFIGURATION_ID && customError}
+			<div class="mt-3 rounded-lg border border-error/40 bg-error/10 px-3 py-2 text-sm text-error">
+				{customError}
+			</div>
+		{/if}
+	</div>
+
 	<div class="size-full overflow-hidden">
-		{#if selected !== null}
-			{#key selected}
-				{@const configuration = configurations[selected]}
+		{#if activeConfiguration}
+			{#key renderKey}
+				{@const configuration = activeConfiguration}
 				<SvelteTimeSeries
 					table={configuration.tables}
 					markers={configuration.markers}
 					debug={false}
-					containerClass="relative grid grid-cols-[300px_1fr] size-full"
-					snippetclass="flex flex-col p-2 gap-2 overflow-hidden"
+					externalManagerLegend={legendMode === 'external'}
+					containerClass={showCustomSidebar
+						? 'relative grid grid-cols-[300px_1fr] size-full'
+						: 'relative size-full'}
+					snippetclass={showCustomSidebar ? 'flex flex-col p-2 gap-2 overflow-hidden' : 'hidden'}
 					chartClass="w-full h-full"
 				>
 					{#snippet columnsSnippet(props)}
-						{#if props.columns.length > 0}
+						{#if showCustomSidebar && props.columns.length > 0}
 							<details
 								class="collapse collapse-arrow bg-base-300 border border-base-300 min-h-[3.6rem] max-h-full"
 								name="data"
@@ -185,48 +453,50 @@
 					{/snippet}
 
 					{#snippet markersSnippet(props)}
-						<details
-							class="collapse collapse-arrow bg-base-300 border border-base-300 min-h-[3.6rem] max-h-full"
-							name="data"
-							open
-						>
-							<summary class="collapse-title font-semibold"> MARKERS </summary>
-							<div class="collapse-content text-sm p-0">
-								<ul class="list overflow-auto h-full bg-base-100">
-									{#each props.markers as marker, i}
-										<li class="list-row">
-											<div class="flex items-center">
-												<button
-													class="btn btn-primary btn-xs"
-													onclick={() => props.goToMarker(marker._ts)}
-												>
-													Go to
-												</button>
-											</div>
-											<div class="list-col-grow">
-												<div class="font-bold">{marker.text}</div>
-											</div>
-											<div class="flex items-center">
-												<label class="swap">
-													<input
-														type="checkbox"
-														checked={true}
-														onchange={() => props.toggleMarker(i, marker.shape)}
-													/>
+						{#if showCustomSidebar}
+							<details
+								class="collapse collapse-arrow bg-base-300 border border-base-300 min-h-[3.6rem] max-h-full"
+								name="data"
+								open
+							>
+								<summary class="collapse-title font-semibold"> MARKERS </summary>
+								<div class="collapse-content text-sm p-0">
+									<ul class="list overflow-auto h-full bg-base-100">
+										{#each props.markers as marker, i}
+											<li class="list-row">
+												<div class="flex items-center">
+													<button
+														class="btn btn-primary btn-xs"
+														onclick={() => props.goToMarker(marker._ts)}
+													>
+														Go to
+													</button>
+												</div>
+												<div class="list-col-grow">
+													<div class="font-bold">{marker.text}</div>
+												</div>
+												<div class="flex items-center">
+													<label class="swap">
+														<input
+															type="checkbox"
+															checked={true}
+															onchange={() => props.toggleMarker(i, marker.shape)}
+														/>
 
-													<div class="swap-on">
-														<EyeIcon />
-													</div>
-													<div class="swap-off">
-														<EyeOffIcon />
-													</div>
-												</label>
-											</div>
-										</li>
-									{/each}
-								</ul>
-							</div>
-						</details>
+														<div class="swap-on">
+															<EyeIcon />
+														</div>
+														<div class="swap-off">
+															<EyeOffIcon />
+														</div>
+													</label>
+												</div>
+											</li>
+										{/each}
+									</ul>
+								</div>
+							</details>
+						{/if}
 					{/snippet}
 
 					{#snippet performanceSnippet(props)}
@@ -242,9 +512,12 @@
 				</SvelteTimeSeries>
 			{/key}
 		{:else}
-			<dvi class="flex items-center justify-center size-full">
-				<div class="text-4xl font-light text-stone-400">Select a table</div>
-			</dvi>
+			<div class="flex items-center justify-center size-full">
+				<div class="text-center">
+					<div class="text-4xl font-light text-stone-400">Configure a source</div>
+					<div class="mt-2 text-stone-500">Select `Custom source`, complete the inputs, and press `Load`.</div>
+				</div>
+			</div>
 		{/if}
 	</div>
 </div>

--- a/packages/svelte-timeseries/src/routes/+page.svelte
+++ b/packages/svelte-timeseries/src/routes/+page.svelte
@@ -84,7 +84,7 @@
 	const activeConfiguration = $derived<DemoConfiguration | null>(
 		selected === CUSTOM_CONFIGURATION_ID
 			? loadedCustomConfiguration
-			: configurations[Number(selected.replace('preset:', ''))] ?? null
+			: (configurations[Number(selected.replace('preset:', ''))] ?? null)
 	);
 
 	const renderKey = $derived(
@@ -353,9 +353,7 @@
 								bind:value={customMainColumn}
 								disabled={inspectingCustomFile || customColumns.length === 0}
 							>
-								<option value="" disabled selected={!customMainColumn}>
-									Select column
-								</option>
+								<option value="" disabled selected={!customMainColumn}> Select column </option>
 								{#each customColumns as column}
 									<option value={column}>{column}</option>
 								{/each}
@@ -369,11 +367,9 @@
 				<button
 					class="btn btn-primary"
 					onclick={loadCustomSource}
-					disabled={
-						sourceMode === 'url'
-							? !customUrl.trim() || !customMainColumn.trim()
-							: !customFile || !customMainColumn || inspectingCustomFile
-					}
+					disabled={sourceMode === 'url'
+						? !customUrl.trim() || !customMainColumn.trim()
+						: !customFile || !customMainColumn || inspectingCustomFile}
 				>
 					{inspectingCustomFile ? 'Reading parquet...' : 'Load'}
 				</button>
@@ -383,8 +379,8 @@
 		{#if selected === CUSTOM_CONFIGURATION_ID}
 			<div class="mt-3 text-sm text-base-content/70">
 				The parquet file can provide the time column as <code>_ts</code>, <code>ts</code>,
-				<code>_t</code>, or <code>t</code>. In file mode: 1. select the parquet file, 2. choose
-				the <code>mainColumn</code>, 3. press <code>Load</code>.
+				<code>_t</code>, or <code>t</code>. In file mode: 1. select the parquet file, 2. choose the
+				<code>mainColumn</code>, 3. press <code>Load</code>.
 			</div>
 		{/if}
 
@@ -515,7 +511,9 @@
 			<div class="flex items-center justify-center size-full">
 				<div class="text-center">
 					<div class="text-4xl font-light text-stone-400">Configure a source</div>
-					<div class="mt-2 text-stone-500">Select `Custom source`, complete the inputs, and press `Load`.</div>
+					<div class="mt-2 text-stone-500">
+						Select `Custom source`, complete the inputs, and press `Load`.
+					</div>
 				</div>
 			</div>
 		{/if}

--- a/packages/sveltecharts/src/lib/SVECharts.svelte
+++ b/packages/sveltecharts/src/lib/SVECharts.svelte
@@ -78,6 +78,7 @@
 	const theme = $derived(mergedConfig.theme);
 	const renderer = $derived(mergedConfig.renderer);
 	const option = $derived(mergedConfig.option);
+	const resolvedTheme = $derived(theme ?? { backgroundColor: isDark ? '#100c2a' : '#fff' });
 
 	const handleDataZoom = (zoomEvent: unknown) => {
 		if (!onDataZoom) {
@@ -100,11 +101,15 @@
 	};
 
 	function chartAction(element: HTMLElement) {
-		instance = init(element, undefined, { renderer });
+		instance = init(element, resolvedTheme, { renderer });
 
 		const handleResize = () => {
 			instance.resize();
 		};
+		const resizeObserver =
+			typeof ResizeObserver === 'undefined' ? undefined : new ResizeObserver(handleResize);
+
+		resizeObserver?.observe(element);
 		window.addEventListener('resize', handleResize);
 		instance.on('datazoom', handleDataZoom);
 
@@ -112,6 +117,7 @@
 			instance.setOption(option);
 		}
 
+		handleResize();
 		onClear = () => instance.clear();
 
 		onLoad(instance);
@@ -120,6 +126,7 @@
 			destroy() {
 				instance.off('datazoom', handleDataZoom);
 				window.removeEventListener('resize', handleResize);
+				resizeObserver?.disconnect();
 				instance.dispose();
 			}
 			/**
@@ -137,7 +144,7 @@
 
 	$effect(() => {
 		if (instance) {
-			instance.setTheme({ backgroundColor: isDark ? '#100c2a' : '#fff' });
+			instance.setTheme(resolvedTheme);
 		}
 	});
 </script>
@@ -150,7 +157,7 @@
 	.echarts {
 		width: 100%;
 		height: 100%;
-		min-height: 300px;
+		min-height: 100px;
 		position: relative;
 		z-index: 1;
 	}

--- a/packages/sveltecharts/tests/un/TimeSeriesChartBuilder.test.ts
+++ b/packages/sveltecharts/tests/un/TimeSeriesChartBuilder.test.ts
@@ -82,16 +82,12 @@ describe('TimeSeriesChartBuilder', () => {
 				[2000, 101, 201]
 			];
 
-			expect(() => builder.setDataset(data, ['_ts', 'price'])).toThrow(
-				'Dimensions length'
-			);
+			expect(() => builder.setDataset(data, ['_ts', 'price'])).toThrow('Dimensions length');
 		});
 
 		it('throws with less than 2 rows', () => {
 			const data = [[1000, 100]];
-			expect(() => builder.setDataset(data, ['_ts', 'price'])).toThrow(
-				'Minimum data length is 2'
-			);
+			expect(() => builder.setDataset(data, ['_ts', 'price'])).toThrow('Minimum data length is 2');
 		});
 	});
 
@@ -285,9 +281,7 @@ describe('TimeSeriesChartBuilder', () => {
 				price: [100, 101]
 			});
 
-			builder.addMarkerEvents([
-				{ xAxis: [1000, 2000], color: 'red', name: 'Event' }
-			]);
+			builder.addMarkerEvents([{ xAxis: [1000, 2000], color: 'red', name: 'Event' }]);
 
 			const opts = (echarts.setOption as ReturnType<typeof vi.fn>).mock.calls;
 			const lastCall = opts[opts.length - 1][0];
@@ -304,11 +298,15 @@ describe('TimeSeriesChartBuilder', () => {
 				price: [100, 101, 102]
 			});
 
-			builder.addMarkerPoint(0, {
-				dimName: 'price',
-				timestamp: 2000,
-				name: 'Buy'
-			}, { icon: 'pin', color: 'green' });
+			builder.addMarkerPoint(
+				0,
+				{
+					dimName: 'price',
+					timestamp: 2000,
+					name: 'Buy'
+				},
+				{ icon: 'pin', color: 'green' }
+			);
 
 			const opts = (echarts.setOption as ReturnType<typeof vi.fn>).mock.calls[0][0];
 			const priceSeries = opts.series.find((s: any) => s.id === 'price');


### PR DESCRIPTION
## Summary

This PR adds direct Parquet input support to `@qtsurfer/svelte-timeseries` and updates the demo so both remote and local data sources can be tested from the UI.

## Changes

- add support for passing Parquet data directly to `SvelteTimeSeries`
- keep backward compatibility with URL-based Parquet loading
- add `externalManagerLegend` as a configurable prop with default `true`
- support time columns named `_ts`, `ts`, `_t`, or `t`
- normalize timestamp handling for both epoch-based and timestamp-based inputs
- fix marker timestamp normalization
- update internal-legend behavior so all available columns are loaded automatically
- add a demo flow to switch between `URL` and `File` sources
- add local file upload support for `.parquet` and `.pqt`
- add file inspection in the demo to detect available columns before loading
- hide custom external column controls when using internal legend mode
- update README examples and API docs

## Demo behavior

- `Custom source` now supports:
  - `URL` mode: enter remote parquet URL + main column
  - `File` mode: upload parquet, inspect columns, choose main column, then press `Load`
- the demo also lets you switch between:
  - `External` legend
  - `Internal` legend

## Notes

- in `internal` legend mode, all available columns are preloaded so ECharts can show them in the built-in legend
- this is more convenient for exploration, but may be heavier for very large datasets